### PR TITLE
feat: improvements to uploads and descriptions

### DIFF
--- a/src/actions/postFileIds.ts
+++ b/src/actions/postFileIds.ts
@@ -5,14 +5,17 @@ import { checkIfAdminAndGetUserId } from "@utils/actions";
 
 export const postFileIds = defineAction({
   input: z.object({
-    fileIds: z.array(z.string()),
+    files: z.array(z.object({
+      id: z.string(),
+      name: z.string(),
+    })),
   }),
   handler: async (input, context) => {
     const userId = await checkIfAdminAndGetUserId(context.request.headers);
     const batchId = crypto.randomUUID();
 
-    const events = input.fileIds.map((id) => {
-      return sendEvent(id, userId, batchId);
+    const events = input.files.map((file) => {
+      return sendEvent(file.id, userId, batchId, file.name);
     });
 
     // make sure events were dispatched
@@ -22,13 +25,14 @@ export const postFileIds = defineAction({
   },
 });
 
-async function sendEvent(fileId: string, userId: string, batchId: string) {
+async function sendEvent(fileId: string, userId: string, batchId: string, fileName: string) {
   return inngest.send({
     name: "keyworder/image.describe",
     data: {
       fileId,
       userId,
       batchId,
+      fileName,
     },
   });
 }

--- a/src/components/ImageDescriptions.svelte
+++ b/src/components/ImageDescriptions.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { Description } from "@utils/db";
-  import { onMount } from "svelte";
+  import { onDestroy, onMount } from "svelte";
   import { actions } from "astro:actions";
   import ImageWithLoading from "./ImageWithLoading.svelte";
   import Icon from "@iconify/svelte";
@@ -11,7 +11,10 @@
   let batchId: string | null = $state(null);
   let attempts: number = $state(0);
   let errorMessage: string | undefined = $state(undefined);
+  let timeoutId: number | undefined = $state(undefined);
+
   const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
   onMount(() => {
     const urlParams = new URLSearchParams(window.location.search);
     batchId = urlParams.get("id");
@@ -29,7 +32,7 @@
         throw error;
       }
 
-      if (data.length > 0 && data.every((image) => image.title && image.description)) {
+      if (data.length > 0 && data.every((image) => image.result || image.description)) {
         descriptions = data;
       } else {
         fetchEventsComplete(id);
@@ -47,7 +50,7 @@
       if (data.complete) {
         fetchBatch(id);
       } else if (attempts < 5) {
-        setTimeout(() => fetchEventsComplete(id), 5000);
+        timeoutId = setTimeout(() => fetchEventsComplete(id), 5000) as unknown as number;
         attempts++;
       } else {
         const message =
@@ -57,6 +60,12 @@
       }
     });
   }
+
+  onDestroy(() => {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  });
 </script>
 
 <section class="text-75 divide-y-2 space-y-4 mt-2">
@@ -75,7 +84,13 @@
         </div>
         <div class="lg:col-span-2 p-1">
           <h3 class="font-black text-xl">{description.title}</h3>
-          <p class="text-sm text-50">file.png</p>
+          <p class="text-sm text-50">{description.file_name}</p>
+          {#if description.result !== "success"}
+            <p class="text-sm text-red-600">
+              The image description failed. Please try again and make sure the image does not contain content that
+              breaks the Terms of Service.
+            </p>
+          {/if}
           <p class="my-2">{description.description}</p>
           <div class="flex gap-2 flex-wrap">
             {#if description.keywords}

--- a/src/components/ImageDescriptions.svelte
+++ b/src/components/ImageDescriptions.svelte
@@ -4,7 +4,6 @@
   import { actions } from "astro:actions";
   import ImageWithLoading from "./ImageWithLoading.svelte";
   import Icon from "@iconify/svelte";
-  import "@uploadthing/svelte/styles.css";
 
   let { appId }: { appId: string } = $props();
   let descriptions: Description[] | undefined = $state(undefined);

--- a/src/components/ImageUploader.svelte
+++ b/src/components/ImageUploader.svelte
@@ -37,7 +37,7 @@
     isSubmitting = true;
 
     const { error, data } = await actions.postFileIds({
-      fileIds: files.map((file) => file.key),
+      files: files.map((file) => ({ id: file.key, name: file.name })),
     });
 
     if (error) {

--- a/src/inngest/types.ts
+++ b/src/inngest/types.ts
@@ -7,6 +7,7 @@ interface ImageDescribeEvent {
     fileId: string;
     userId: string;
     batchId: string;
+    fileName: string;
   };
 }
 

--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -30,11 +30,14 @@ export interface DescriptionTable {
   id: Generated<string>;
   job_id: string;
   file_id: string;
+  file_name: string | null;
   keywords: string[] | null;
   description: string | null;
   title: string | null;
   user_id: string;
   batch_id: string;
+  tokens_used: number | null;
+  result: string | null;
   created_at: ColumnType<Date, string | undefined, never>;
 }
 


### PR DESCRIPTION
- display file name of the image in the batches page
- insert info about failed batches in the database. let's say the description fails for one image -> set image status as fail, otherwise success
- save the number of tokens used