### PR TITLE
Update inngest AI model to gpt-5.4-nano

### DIFF
--- a/src/constants/ai.ts
+++ b/src/constants/ai.ts
@@ -1,1 +1,1 @@
-export const AI_MODEL = "gpt-4.1-nano";
+export const AI_MODEL = "gpt-5.4-nano";


### PR DESCRIPTION
Updates the AI model constant used by the Inngest image description functions from gpt-4.1-nano to gpt-5.4-nano.