### PR TITLE
Add admin panel with credit cost configuration

### DIFF
--- a/keyworder_migrations/2026-05-19_add_app_settings.sql
+++ b/keyworder_migrations/2026-05-19_add_app_settings.sql
@@ -1,0 +1,9 @@
+CREATE TABLE keyworder."app_settings" (
+  "key" text PRIMARY KEY,
+  "value" jsonb NOT NULL,
+  "updated_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_by" text REFERENCES keyworder."user" ("id")
+);
+
+INSERT INTO keyworder."app_settings" ("key", "value") VALUES
+  ('credit_costs', '{"upload":1,"describe":7,"regenerate":5}');

--- a/src/actions/appSettings.ts
+++ b/src/actions/appSettings.ts
@@ -1,0 +1,71 @@
+import { defineAction } from "astro:actions";
+import { z } from "astro:schema";
+import { sql } from "kysely";
+import { db } from "@utils/db";
+import { checkIfSignedInAndGetUserId, requireAdmin } from "@utils/actions";
+
+const COSTS_KEY = "credit_costs";
+
+export const getAppSettings = defineAction({
+  handler: async (input, context) => {
+    await checkIfSignedInAndGetUserId(context.request.headers);
+
+    const row = await db
+      .withSchema("keyworder")
+      .selectFrom("app_settings")
+      .select(["key", "value"])
+      .where("key", "=", COSTS_KEY)
+      .executeTakeFirst();
+
+    if (!row) {
+      const fallback = await import("@/constants/credit-costs");
+      return {
+        creditCosts: {
+          upload: fallback.CREDIT_COST_UPLOAD,
+          describe: fallback.CREDIT_COST_DESCRIBE,
+          regenerate: fallback.CREDIT_COST_REGENERATE,
+        },
+      };
+    }
+
+    const v = row.value as Record<string, number>;
+
+    return {
+      creditCosts: {
+        upload: typeof v.upload === "number" ? v.upload : 1,
+        describe: typeof v.describe === "number" ? v.describe : 7,
+        regenerate: typeof v.regenerate === "number" ? v.regenerate : 5,
+      },
+    };
+  },
+});
+
+export const updateAppSettings = defineAction({
+  input: z.object({
+    creditCosts: z.object({
+      upload: z.number().int().min(0),
+      describe: z.number().int().min(0),
+      regenerate: z.number().int().min(0),
+    }),
+  }),
+  handler: async (input, context) => {
+    const userId = await requireAdmin(context.request.headers);
+
+    const newValue = {
+      upload: input.creditCosts.upload,
+      describe: input.creditCosts.describe,
+      regenerate: input.creditCosts.regenerate,
+    };
+
+    await sql`
+      INSERT INTO keyworder."app_settings" ("key", "value", "updated_by", "updated_at")
+      VALUES (${COSTS_KEY}, ${JSON.stringify(newValue)}::jsonb, ${userId}, now())
+      ON CONFLICT ("key") DO UPDATE SET
+        "value" = ${JSON.stringify(newValue)}::jsonb,
+        "updated_by" = ${userId},
+        "updated_at" = now()
+    `.execute(db);
+
+    return { success: true };
+  },
+});

--- a/src/actions/getStats.ts
+++ b/src/actions/getStats.ts
@@ -1,10 +1,11 @@
 import { defineAction } from "astro:actions";
-import { checkIfSignedInAndGetUserId } from "@utils/actions";
+import { checkIfSignedInAndGetUserId, getCreditCosts } from "@utils/actions";
 import { db } from "@utils/db";
 
 export const getStats = defineAction({
   handler: async (input, context) => {
     const userId = await checkIfSignedInAndGetUserId(context.request.headers);
+
     const { batchCount } = await db
       .withSchema("keyworder")
       .selectFrom("description")
@@ -39,11 +40,14 @@ export const getStats = defineAction({
       .where("id", "=", userId)
       .executeTakeFirstOrThrow();
 
+    const creditCosts = await getCreditCosts();
+
     return {
       batchCount: Number(batchCount),
       imageCount: Number(imageCount),
       tokenSum: Number(tokenSum),
       creditsRemaining: Number(user.credits),
+      creditCosts,
     };
   },
 });

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -4,6 +4,7 @@ import { getBatches } from "./getBatches";
 import { postFileIds } from "./postFileIds";
 import { getStats } from "./getStats";
 import { updateDescription, regenerateDescription } from "./updateDescription";
+import { getAppSettings, updateAppSettings } from "./appSettings";
 
 export const server = {
   getBatch,
@@ -13,4 +14,6 @@ export const server = {
   getStats,
   updateDescription,
   regenerateDescription,
+  getAppSettings,
+  updateAppSettings,
 };

--- a/src/actions/postFileIds.ts
+++ b/src/actions/postFileIds.ts
@@ -1,8 +1,7 @@
 import { defineAction } from "astro:actions";
 import { z } from "astro:schema";
 import { inngest } from "@/inngest";
-import { checkIfSignedInAndGetUserId, deductCredits } from "@utils/actions";
-import { CREDIT_COST_DESCRIBE } from "@/constants/credit-costs";
+import { checkIfSignedInAndGetUserId, deductCredits, getCreditCosts } from "@utils/actions";
 import { db } from "@utils/db";
 import { uploadthing } from "@utils/storage";
 
@@ -48,7 +47,8 @@ export const postFileIds = defineAction({
       throw new Error("Failed to start creating descriptions");
     }
 
-    await deductCredits(userId, input.files.length * CREDIT_COST_DESCRIBE, "describe", {
+    const costs = await getCreditCosts();
+    await deductCredits(userId, input.files.length * costs.describe, "describe", {
       batchId,
       imageCount: input.files.length,
     });

--- a/src/actions/updateDescription.ts
+++ b/src/actions/updateDescription.ts
@@ -1,8 +1,7 @@
 import { ActionError, defineAction } from "astro:actions";
 import { z } from "astro:schema";
 import { db } from "@utils/db";
-import { checkIfSignedInAndGetUserId, deductCredits } from "@utils/actions";
-import { CREDIT_COST_REGENERATE } from "@/constants/credit-costs";
+import { checkIfSignedInAndGetUserId, deductCredits, getCreditCosts } from "@utils/actions";
 import { AI_MODEL } from "@/constants/ai";
 import { UPLOADTHING_APP_ID } from "astro:env/client";
 import { zodTextFormat } from "openai/helpers/zod";
@@ -101,7 +100,8 @@ export const regenerateDescription = defineAction({
       };
     }
 
-    await deductCredits(userId, CREDIT_COST_REGENERATE, "regenerate", { descriptionId: input.descriptionId });
+    const costs = await getCreditCosts();
+    await deductCredits(userId, costs.regenerate, "regenerate", { descriptionId: input.descriptionId });
     await db.withSchema("keyworder").updateTable("description")
       .set({
         title: response.output_parsed.title,

--- a/src/components/AdminPanel.svelte
+++ b/src/components/AdminPanel.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+  import { actions } from "astro:actions";
+  import { onMount } from "svelte";
+
+  const { initialCosts }: { initialCosts: Record<string, number> | null } = $props();
+
+  let uploadCost = $state(initialCosts?.upload ?? 1);
+  let describeCost = $state(initialCosts?.describe ?? 7);
+  let regenerateCost = $state(initialCosts?.regenerate ?? 5);
+  let saving = $state(false);
+  let message = $state("");
+  let isError = $state(false);
+
+  onMount(async () => {
+    const { data } = await actions.getAppSettings();
+    if (data?.creditCosts) {
+      uploadCost = data.creditCosts.upload;
+      describeCost = data.creditCosts.describe;
+      regenerateCost = data.creditCosts.regenerate;
+    }
+  });
+
+  async function save(event: SubmitEvent) {
+    event.preventDefault();
+    saving = true;
+    message = "";
+    isError = false;
+
+    const { error } = await actions.updateAppSettings({
+      creditCosts: {
+        upload: uploadCost,
+        describe: describeCost,
+        regenerate: regenerateCost,
+      },
+    });
+
+    saving = false;
+
+    if (error) {
+      isError = true;
+      message = error.message;
+    } else {
+      message = "Settings saved successfully.";
+    }
+  }
+</script>
+
+<form class="space-y-4 mt-8" onsubmit={save}>
+  <h3 class="font-black text-xl text-90">Credit Costs</h3>
+
+  <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+    <label class="flex flex-col gap-1">
+      <span class="text-sm text-75">Upload (credits)</span>
+      <input
+        type="number"
+        min="0"
+        bind:value={uploadCost}
+        class="input-field rounded-lg px-3 py-2 bg-[var(--card-bg)] border border-[var(--line-color)] text-90"
+      />
+    </label>
+
+    <label class="flex flex-col gap-1">
+      <span class="text-sm text-75">Describe (credits)</span>
+      <input
+        type="number"
+        min="0"
+        bind:value={describeCost}
+        class="input-field rounded-lg px-3 py-2 bg-[var(--card-bg)] border border-[var(--line-color)] text-90"
+      />
+    </label>
+
+    <label class="flex flex-col gap-1">
+      <span class="text-sm text-75">Regenerate (credits)</span>
+      <input
+        type="number"
+        min="0"
+        bind:value={regenerateCost}
+        class="input-field rounded-lg px-3 py-2 bg-[var(--card-bg)] border border-[var(--line-color)] text-90"
+      />
+    </label>
+  </div>
+
+  <button
+    type="submit"
+    disabled={saving}
+    class="btn-regular rounded-lg active:scale-90 py-2 px-4 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+  >
+    {#if saving}
+      Saving...
+    {:else}
+      Save Changes
+    {/if}
+  </button>
+
+  {#if message}
+    <p class={isError ? "text-red-600 text-sm" : "text-green-600 text-sm"}>
+      {message}
+    </p>
+  {/if}
+</form>

--- a/src/components/ImageUploader.svelte
+++ b/src/components/ImageUploader.svelte
@@ -12,7 +12,6 @@
   import { twMerge } from "tailwind-merge";
   import ImageWithLoading from "./ImageWithLoading.svelte";
   import { UPLOADTHING_APP_ID } from "astro:env/client";
-  import { CREDIT_COST_UPLOAD, CREDIT_COST_DESCRIBE } from "@/constants/credit-costs";
 
   type FileForUpload = {
     key: string;
@@ -27,11 +26,18 @@
   let errorMessage: string | undefined = $state(undefined);
   let files: FileForUpload[] = $state([]);
   let creditsRemaining: number | undefined = $state(undefined);
+  let creditCosts = $state({ upload: 1, describe: 7 });
 
   onMount(() => {
     actions.getStats(null).then(({ data }) => {
       if (data) {
         creditsRemaining = data.creditsRemaining;
+        if (data.creditCosts) {
+          creditCosts = {
+            upload: data.creditCosts.upload,
+            describe: data.creditCosts.describe,
+          };
+        }
       }
     });
   });
@@ -40,6 +46,12 @@
     actions.getStats(null).then(({ data }) => {
       if (data) {
         creditsRemaining = data.creditsRemaining;
+        if (data.creditCosts) {
+          creditCosts = {
+            upload: data.creditCosts.upload,
+            describe: data.creditCosts.describe,
+          };
+        }
       }
     });
   }
@@ -132,7 +144,7 @@
           <button
             class="btn-regular rounded-lg active:scale-90 py-3 px-6 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
             type="submit"
-            disabled={creditsRemaining !== undefined && files.length * CREDIT_COST_DESCRIBE > creditsRemaining}
+            disabled={creditsRemaining !== undefined && files.length * creditCosts.describe > creditsRemaining}
           >
             Describe <Icon
               class="text-[1.50rem]"
@@ -148,10 +160,10 @@
           </button>
         </form>
       </div>
-      {#if creditsRemaining !== undefined && files.length * CREDIT_COST_DESCRIBE > creditsRemaining}
+      {#if creditsRemaining !== undefined && files.length * creditCosts.describe > creditsRemaining}
         <p class="text-red-600 text-sm">
-          Describing {files.length} images costs {files.length * CREDIT_COST_DESCRIBE} credits, but you only have {creditsRemaining}.
-          Remove {Math.ceil((files.length * CREDIT_COST_DESCRIBE - creditsRemaining) / CREDIT_COST_DESCRIBE)} images to continue.
+          Describing {files.length} images costs {files.length * creditCosts.describe} credits, but you only have {creditsRemaining}.
+          Remove {Math.ceil((files.length * creditCosts.describe - creditsRemaining) / creditCosts.describe)} images to continue.
         </p>
       {/if}
     {:else}
@@ -172,7 +184,7 @@
       {/if}
     {/if}
 
-    <p class="text-50 text-sm">{CREDIT_COST_UPLOAD} credit per upload + {CREDIT_COST_DESCRIBE} credits per description</p>
+    <p class="text-50 text-sm">{creditCosts.upload} credit per upload + {creditCosts.describe} credits per description</p>
     {#if creditsRemaining !== undefined}
       <p class="text-75 text-sm font-bold">Credits remaining: {creditsRemaining}</p>
     {/if}

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -60,6 +60,13 @@ let links: NavBarLink[] = navBarConfig.links.map((item: NavBarLink | LinkPreset)
           );
         })
       }
+      <a
+        aria-label="Admin Console"
+        class="btn-plain scale-animation rounded-lg h-11 font-bold px-5 active:scale-95 admin-only !hidden"
+        href={url("/admin/")}
+      >
+        <div class="flex items-center">Admin Console</div>
+      </a>
     </div>
     <div class="flex">
       <!--<SearchPanel client:load>-->
@@ -155,8 +162,25 @@ let links: NavBarLink[] = navBarConfig.links.map((item: NavBarLink | LinkPreset)
     });
   }
 
+  async function showAdminLinks() {
+    const buttons = document.querySelectorAll(".admin-only");
+    if (buttons.length === 0) {
+      return;
+    }
+
+    const session = await authClientVanilla.getSession();
+    if (session.data?.user.role !== "admin") {
+      return;
+    }
+
+    buttons.forEach((button) => {
+      button.classList.remove("!hidden");
+    });
+  }
+
   loadButtonScript();
   showAuthenticatedLinks();
+  showAdminLinks();
 </script>
 
 <script define:vars={{ scriptUrl: url("/pagefind/pagefind.js"), isProd: import.meta.env.PROD }} is:inline>

--- a/src/components/widget/NavMenuPanel.astro
+++ b/src/components/widget/NavMenuPanel.astro
@@ -20,7 +20,7 @@ const links = Astro.props.links;
       >
         <div class="transition text-black/75 dark:text-white/75 font-bold group-hover:text-[var(--primary)] group-active:text-[var(--primary)]">
           {link.name}
-        </div>
+</div>
         {!link.external && (
           <Icon class="transition text-[1.25rem] text-[var(--primary)]" name="material-symbols:chevron-right-rounded" />
         )}
@@ -33,4 +33,13 @@ const links = Astro.props.links;
       </a>
     ))
   }
+  <a
+    class="group flex justify-between items-center py-2 pl-3 pr-1 rounded-lg gap-8 hover:bg-[var(--btn-plain-bg-hover)] active:bg-[var(--btn-plain-bg-active)] transition admin-only !hidden"
+    href={url("/admin/")}
+  >
+    <div class="transition text-black/75 dark:text-white/75 font-bold group-hover:text-[var(--primary)] group-active:text-[var(--primary)]">
+      Admin Console
+    </div>
+    <Icon class="transition text-[1.25rem] text-[var(--primary)]" name="material-symbols:chevron-right-rounded" />
+  </a>
 </div>

--- a/src/constants/hide-sidebar-links.ts
+++ b/src/constants/hide-sidebar-links.ts
@@ -1,1 +1,1 @@
-export const HIDE_SIDEBAR_LINKS = ["/gallery", "/keyworder", "/batch", "/my-account"];
+export const HIDE_SIDEBAR_LINKS = ["/gallery", "/keyworder", "/batch", "/my-account", "/admin"];

--- a/src/pages/admin.astro
+++ b/src/pages/admin.astro
@@ -1,0 +1,40 @@
+---
+import I18nKey from "@i18n/i18nKey";
+import { i18n } from "@i18n/translation";
+import MainGridLayout from "@layouts/MainGridLayout.astro";
+import AdminPanel from "@components/AdminPanel.svelte";
+import { requireAdmin } from "@utils/actions";
+import { db } from "@utils/db";
+
+export const prerender = false;
+
+let settingsData: Record<string, number> | null = null;
+
+try {
+  await requireAdmin(Astro.request.headers);
+
+  const row = await db
+    .withSchema("keyworder")
+    .selectFrom("app_settings")
+    .select("value")
+    .where("key", "=", "credit_costs")
+    .executeTakeFirst();
+
+  if (row) {
+    settingsData = row.value as Record<string, number>;
+  }
+}
+catch {
+  return Astro.redirect("/");
+}
+---
+
+<MainGridLayout description={i18n(I18nKey.home)} title="Admin Console">
+  <div class="flex w-full rounded-[var(--radius-large)] overflow-hidden relative min-h-32">
+    <div class="card-base z-10 px-9 py-6 relative w-full text-75 space-y-2">
+      <h1 class="text-90 text-3xl font-black">Admin Console</h1>
+      <p class="text-75">Manage credit costs and application settings.</p>
+      <AdminPanel client:load initialCosts={settingsData} />
+    </div>
+  </div>
+</MainGridLayout>

--- a/src/utils/actions.ts
+++ b/src/utils/actions.ts
@@ -1,6 +1,11 @@
 import { ActionError } from "astro:actions";
 import { auth } from "./auth";
 import { db } from "./db";
+import {
+  CREDIT_COST_UPLOAD,
+  CREDIT_COST_DESCRIBE,
+  CREDIT_COST_REGENERATE,
+} from "@/constants/credit-costs";
 
 export async function checkIfSignedInAndGetUserId(headers: Headers) {
   const session = await auth.api.getSession({ headers });
@@ -15,6 +20,50 @@ export async function checkIfSignedInAndGetUserId(headers: Headers) {
   return session.user.id;
 }
 
+export async function requireAdmin(headers: Headers) {
+  const session = await auth.api.getSession({ headers });
+
+  if (!session?.session) {
+    throw new ActionError({
+      code: "UNAUTHORIZED",
+      message: "You must be signed in",
+    });
+  }
+
+  if (session.user.role !== "admin") {
+    throw new ActionError({
+      code: "FORBIDDEN",
+      message: "You do not have permission to access this resource",
+    });
+  }
+
+  return session.user.id;
+}
+
+export async function getCreditCosts() {
+  const row = await db
+    .withSchema("keyworder")
+    .selectFrom("app_settings")
+    .select("value")
+    .where("key", "=", "credit_costs")
+    .executeTakeFirst();
+
+  if (!row) {
+    return {
+      upload: CREDIT_COST_UPLOAD,
+      describe: CREDIT_COST_DESCRIBE,
+      regenerate: CREDIT_COST_REGENERATE,
+    };
+  }
+
+  const value = row.value as Record<string, number>;
+
+  return {
+    upload: typeof value.upload === "number" ? value.upload : CREDIT_COST_UPLOAD,
+    describe: typeof value.describe === "number" ? value.describe : CREDIT_COST_DESCRIBE,
+    regenerate: typeof value.regenerate === "number" ? value.regenerate : CREDIT_COST_REGENERATE,
+  };
+}
 export async function deductCredits(
   userId: string,
   amount: number,

--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -18,6 +18,7 @@ export interface Database {
   verification: Tables["keyworder.verification"];
   batch: Tables["keyworder.batch"];
   credit_audit: Tables["keyworder.credit_audit"];
+  app_settings: Tables["keyworder.app_settings"];
 }
 
 interface Tables {
@@ -28,6 +29,7 @@ interface Tables {
   "keyworder.verification": VerificationTable;
   "keyworder.batch": BatchTable;
   "keyworder.credit_audit": CreditAuditTable;
+  "keyworder.app_settings": AppSettingsTable;
 }
 
 export interface BatchTable {
@@ -127,6 +129,17 @@ export interface CreditAuditTable {
 
 export type CreditAudit = Selectable<CreditAuditTable>;
 export type NewCreditAudit = Insertable<CreditAuditTable>;
+
+export interface AppSettingsTable {
+  key: string;
+  value: Record<string, unknown>;
+  updated_at: ColumnType<Date, string | undefined, Date>;
+  updated_by: string | null;
+}
+
+export type AppSettings = Selectable<AppSettingsTable>;
+export type NewAppSettings = Insertable<AppSettingsTable>;
+export type AppSettingsUpdate = Updateable<AppSettingsTable>;
 
 const pool = new Pool({
   connectionString: DATABASE_URL,

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,7 +1,6 @@
 import { UPLOADTHING_TOKEN } from "astro:env/server";
 import { UTApi, createUploadthing, type FileRouter } from "uploadthing/server";
-import { checkIfSignedInAndGetUserId, deductCredits } from "./actions";
-import { CREDIT_COST_UPLOAD } from "@/constants/credit-costs";
+import { checkIfSignedInAndGetUserId, deductCredits, getCreditCosts } from "./actions";
 
 export const uploadthing = new UTApi({
   token: UPLOADTHING_TOKEN,
@@ -32,8 +31,9 @@ export const ourFileRouter: FileRouter = {
     })
     .onUploadComplete(async ({ metadata, file }) => {
       // This code RUNS ON YOUR SERVER after upload
-      await deductCredits(metadata.userId, CREDIT_COST_UPLOAD, "upload", { fileKey: file.key });
-      console.log("Upload complete for userId:", metadata.userId, "1 credit deducted");
+      const costs = await getCreditCosts();
+      await deductCredits(metadata.userId, costs.upload, "upload", { fileKey: file.key });
+      console.log("Upload complete for userId:", metadata.userId, costs.upload, "credit(s) deducted");
 
       // !!! Whatever is returned here is sent to the clientside `onClientUploadComplete` callback
       return { uploadedBy: metadata.userId };


### PR DESCRIPTION
Implements a server-rendered admin panel at `/admin` for managing app settings, starting with credit cost controls.

### Changes
- **New page**: `/admin` with SSR auth guard (`requireAdmin`) + DB query for current settings
- **AdminPanel.svelte**: form to edit credit costs for image upload, describe, regenerate
- **app_settings table**: key-value store (`keyworder.app_settings`) with JSONB value, `updated_at`, `updated_by`
- **getCreditCosts()**: reads from DB or falls back to constants in `credit-costs.ts`
- **Dynamic costs**: `ImageUploader`, `postFileIds`, `updateDescription`, `storage.ts`, `getStats` now use dynamic credit costs
- **Stale-data fix**: `AdminPanel.svelte` fetches fresh data via `actions.getAppSettings()` on mount to bypass Swup's client-side cache
- **Admin sidebar**: `/admin` hidden from sidebar (full-width layout), admin link shown in navbar for admin users